### PR TITLE
fix ring shader issues with light directions, and some interpolated but not normalized world positions

### DIFF
--- a/shaders/readme.md
+++ b/shaders/readme.md
@@ -1,6 +1,6 @@
 # How to compile the ring shader
 
-1) Get [Unity version that matches KSP] (5.4.0p4 for 1.2.2 and 1.3.0)
+1) Get [Unity version that matches KSP] (2019.2.2f1 at this time for 1.9 and 1.10)
 
 2) Clone https://github.com/Kopernicus/shader-export
 


### PR DESCRIPTION
Fixed some issues resulting in the ring shader not correctly lit (appearing to not be lit from the correct direction).

Not sure if this fixes flickering or not as I didn't run into it. I posted the compiled shaders (compiled for latest KSP unity version) in discord. Note: didn't test with OpenGL but it should have compiled correctly for it.