### PR TITLE
Support Breaking Ground anomalies out of the box

### DIFF
--- a/src/Kopernicus/Configuration/PQSLoader.cs
+++ b/src/Kopernicus/Configuration/PQSLoader.cs
@@ -506,6 +506,19 @@ namespace Kopernicus.Configuration
                 newScTree.name = "KSC";
             }
 
+            // Add the PQSROCControl mod for surface anomalies
+            if (!Utility.HasMod<PQSROCControl>(Value))
+            {
+                PQSROCControl roc = Utility.AddMod<PQSROCControl>(Value, 999999);
+                roc.rocs = new List<LandClassROC>();
+                roc.currentCBName = Value.name;
+            }
+            else
+            {
+                PQSROCControl roc = Utility.GetMod<PQSROCControl>(Value);
+                roc.currentCBName = Value.name;
+            }
+
             // Load existing mods
             PQSMod[] mods = Utility.GetMods<PQSMod>(Value);
             for (Int32 i = 0; i < mods.Length; i++)
@@ -611,6 +624,19 @@ namespace Kopernicus.Configuration
             if (!Utility.HasMod<PQSMod_TextureAtlasFixer>(Value))
             {
                 Utility.AddMod<PQSMod_TextureAtlasFixer>(Value, 0);
+            }
+
+            // Add the PQSROCControl mod for surface anomalies
+            if (!Utility.HasMod<PQSROCControl>(Value))
+            {
+                PQSROCControl roc = Utility.AddMod<PQSROCControl>(Value, 999999);
+                roc.rocs = new List<LandClassROC>();
+                roc.currentCBName = Value.name;
+            }
+            else
+            {
+                PQSROCControl roc = Utility.GetMod<PQSROCControl>(Value);
+                roc.currentCBName = Value.name;
             }
 
             // Load existing mods


### PR DESCRIPTION
The surface anomalies that were added with the Breaking Ground DLC have their own stock configuration system, but they rely on a PQSMod that needs to be added to a body with anomalies.

That in itself wouldn't be a huge problem, because you could always template bodies that already have this mod. However, the PQSMod has a design flaw: It doesn't actively look for the body it is attached to, instead it simply stores the name in a string variable.

That means if you create a body called "Kopernicus", with Vall as it's template, the string variable will still contain the string "Vall", and the ROC system will spawn the anomalies for Vall on that body. If you add anomalies for "Kopernicus", they will by ignored.

This code does the same that the "MyRocksAreBiggerThanYours" plugin that I wrote for JNSQ a while ago does, but that was always just a stopgap solution. Integrating it into Kopernicus is more universal.

---
Like the other PR, this was written in my text editor. Should work fine though.
