### PR TITLE
Update SolarPanels.cfg

### DIFF
--- a/build/GameData/Kopernicus/Config/SolarPanels.cfg
+++ b/build/GameData/Kopernicus/Config/SolarPanels.cfg
@@ -39,7 +39,7 @@
             {
 				@IDENTIFIER[ModuleDeployableSolarPanel]
 				{
-					@name = *SolarPanel*
+					@name = KopernicusSolarPanels
 				}
             }
         }


### PR DESCRIPTION
I tried to be too clever and created this issue.  It turns out that KSPIE adds a module called FNSolarPanelWasteHeatModule so the B9 switch there are two modules that the B9 sees that fit the filter and throws an exception.  Going back to this seems to work in all of the known cases that you've run into prior including JNSQ, BDB as well.