### PR TITLE
use body data

### DIFF
--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -422,12 +422,9 @@ namespace Kopernicus.RuntimeUtility
                    continue;
                 }
        
-                Double rotPeriod = Utility
-                    .FindBody(PSystemManager.Instance.systemPrefab.rootBody, body.transform.name).celestialBody
-                    .rotationPeriod;
-                Double num1 = Math.PI * 2 * Math.Sqrt(Math.Pow(Math.Abs(body.orbit.semiMajorAxis), 3) /
-                                                      body.orbit.referenceBody.gravParameter);
-                body.rotationPeriod = rotPeriod * num1 / (num1 + rotPeriod);
+                Double rotationPeriod = body.rotationPeriod;
+                Double orbitalPeriod = body.orbit.period;
+                body.rotationPeriod = rotationPeriod * orbitalPeriod / (orbitalPeriod + rotationPeriod);
             }
 
             // Update the order in the tracking station


### PR DESCRIPTION
not sure why this was hardcoded this way, the data seems to be available
for the body.rotationPeriod and body.orbit.period so they can be used as
far as I can tell