### PR TITLE
Texture Exporter Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -256,3 +256,4 @@ $RECYCLE.BIN/
 
 # Kopernicus
 build/GameData/Kopernicus/Cache/
+src/Kopernicus/Kopernicus.csproj

--- a/src/Kopernicus/Components/KopernicusStar.cs
+++ b/src/Kopernicus/Components/KopernicusStar.cs
@@ -36,7 +36,7 @@ namespace Kopernicus.Components
     /// <summary>
     /// Implementation of the <see cref="Sun"/> API.
     /// </summary>
-    public class KopernicusStar : Sun
+    public class KopernicusStar : Sun //
     {
         /// <summary>
         /// A list of all stars

--- a/src/Kopernicus/Kopernicus.csproj
+++ b/src/Kopernicus/Kopernicus.csproj
@@ -30,48 +30,57 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
     <Reference Include="Kopernicus.Parser">
-      <HintPath>H:\KSP1111\GameData\Kopernicus\Plugins\Kopernicus.Parser.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\GameData\Kopernicus\Plugins\Kopernicus.Parser.dll</HintPath>
     </Reference>
     <Reference Include="ModularFlightIntegrator">
-      <HintPath>H:\KSP1111\GameData\ModularFlightIntegrator\ModularFlightIntegrator.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\GameData\ModularFlightIntegrator\ModularFlightIntegrator.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
+    <Reference Include="UnityEngine">
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.ImageConversionModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.ImageConversionModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.InputLegacyModule.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.ParticleSystemModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.ParticleSystemModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.PhysicsModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.PhysicsModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UI">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.UI.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.UnityWebRequestWWWModule">
-      <HintPath>H:\KSP1111\KSP_x64_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
+      <HintPath>H:\Games\SteamLibrary\steamapps\common\Kerbal Space Program - BH\KSP_x64_Data\Managed\UnityEngine.UnityWebRequestWWWModule.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/Kopernicus/Utility.cs
+++ b/src/Kopernicus/Utility.cs
@@ -734,7 +734,7 @@ namespace Kopernicus
                 {
                     if (by == 0 || by == result.height - 1 || Math.Abs(source.GetPixel(bx, by).r) < 0.01)
                     {
-                        result.SetPixel(bx, by, new Color(0.5f, 0.5f, 0.5f, 0.5f));
+                        result.SetPixel(bx, by, new Color(0.5f, 0.5f, 1f, 1f));
                     }
                     else
                     {
@@ -750,7 +750,7 @@ namespace Kopernicus
                         Double slopeX = (1 + dX / Math.Pow(dX * dX + dS * dS, 0.5) * strength) / 2;
                         Double slopeY = (1 + dY / Math.Pow(dY * dY + dS * dS, 0.5) * strength) / 2;
 
-                        result.SetPixel(bx, by, new Color((Single)slopeY, (Single)slopeY, (Single)slopeY, (Single)slopeX));
+                        result.SetPixel(bx, by, new Color((float)slopeX, (float)slopeY, (float)1, (float)1));
                     }
                 }
             }


### PR DESCRIPTION
TextureDelta calculated automatically so that heightmaps use the entire contrast range. Export a second texture that includes positive offsets. Export proper normals that, when converted to DXT5_NM, look much better in-game.

Also worth removing the `src/Kopernicus/Kopernicus.csproj` from the gitignore - it's so your references are not changed