### PR TITLE
Fix logspam in non-flight scenes with `force3DOrbits` enabled

### DIFF
--- a/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
+++ b/src/Kopernicus/RuntimeUtility/RuntimeUtility.cs
@@ -572,9 +572,11 @@ namespace Kopernicus.RuntimeUtility
             {
                 return;
             }
-
-            MapView.fetch.max3DlineDrawDist = Single.MaxValue;
-            GameSettings.MAP_MAX_ORBIT_BEFORE_FORCE2D = Int32.MaxValue;
+            if (MapView.fetch)
+            {
+                MapView.fetch.max3DlineDrawDist = Single.MaxValue;
+                GameSettings.MAP_MAX_ORBIT_BEFORE_FORCE2D = Int32.MaxValue;
+            }
         }
 
         // The preset names


### PR DESCRIPTION
Enabling `force3DOrbits`, which fixes some long-standing issues in RSS (namely, flickering orbit lines and incorrect occlusion), causes severe NRE spam in non-flight scenes. This patch fixes the logspam by adding a null check for `MapView.fetch`.

cc @siimav and @vader111.